### PR TITLE
Update the version of Alpine Linux to 3.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.1
+FROM alpine:3.6
 MAINTAINER Marcel Maatkamp <m.maatkamp@gmail.com>
 
 WORKDIR /projects

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Freeradius Docker image
 
-Lightweight and fast Freeradius3 v3.0.11-r0 server. This image is based on the minimalistic Alpine Linux and is currently 62MB. 
+Lightweight and fast Freeradius3 v3.0.13-r2 server. This image is based on the minimalistic Alpine Linux and is currently 62MB. 
 
 ## How to use 
 


### PR DESCRIPTION
Resolves #7 

Update the version of Alpine Linux to 3.6. The freeradius and freeradius-sqlite packages in 3.6 correctly install the SQLite configuration files and initial schema.